### PR TITLE
Add section name to module tabs

### DIFF
--- a/app/modules/daily_ops/view.py
+++ b/app/modules/daily_ops/view.py
@@ -2,10 +2,14 @@ from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QTabWidget
 
 
 class DailyOpsView(QTabWidget):
+    SECTION_TITLE = "العمليات اليومية"
+
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self.addTab(self._create_tab('محتوى التبويب 1'), 'تبويب 1')
-        self.addTab(self._create_tab('محتوى التبويب 2'), 'تبويب 2')
+
+        for i in (1, 2):
+            tab_name = f"تبويب {i} {self.SECTION_TITLE}"
+            self.addTab(self._create_tab(f"محتوى {tab_name}"), tab_name)
 
     def _create_tab(self, text: str) -> QWidget:
         widget = QWidget()

--- a/app/modules/employees/view.py
+++ b/app/modules/employees/view.py
@@ -2,10 +2,14 @@ from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QTabWidget
 
 
 class EmployeesView(QTabWidget):
+    SECTION_TITLE = "العاملون"
+
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self.addTab(self._create_tab('محتوى التبويب 1'), 'تبويب 1')
-        self.addTab(self._create_tab('محتوى التبويب 2'), 'تبويب 2')
+
+        for i in (1, 2):
+            tab_name = f"تبويب {i} {self.SECTION_TITLE}"
+            self.addTab(self._create_tab(f"محتوى {tab_name}"), tab_name)
 
     def _create_tab(self, text: str) -> QWidget:
         widget = QWidget()

--- a/app/modules/equipment/view.py
+++ b/app/modules/equipment/view.py
@@ -2,10 +2,14 @@ from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QTabWidget
 
 
 class EquipmentView(QTabWidget):
+    SECTION_TITLE = "المعدات"
+
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self.addTab(self._create_tab('محتوى التبويب 1'), 'تبويب 1')
-        self.addTab(self._create_tab('محتوى التبويب 2'), 'تبويب 2')
+
+        for i in (1, 2):
+            tab_name = f"تبويب {i} {self.SECTION_TITLE}"
+            self.addTab(self._create_tab(f"محتوى {tab_name}"), tab_name)
 
     def _create_tab(self, text: str) -> QWidget:
         widget = QWidget()

--- a/app/modules/finance/view.py
+++ b/app/modules/finance/view.py
@@ -2,10 +2,14 @@ from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QTabWidget
 
 
 class FinanceView(QTabWidget):
+    SECTION_TITLE = "المالية"
+
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self.addTab(self._create_tab('محتوى التبويب 1'), 'تبويب 1')
-        self.addTab(self._create_tab('محتوى التبويب 2'), 'تبويب 2')
+
+        for i in (1, 2):
+            tab_name = f"تبويب {i} {self.SECTION_TITLE}"
+            self.addTab(self._create_tab(f"محتوى {tab_name}"), tab_name)
 
     def _create_tab(self, text: str) -> QWidget:
         widget = QWidget()

--- a/app/modules/notes/view.py
+++ b/app/modules/notes/view.py
@@ -2,10 +2,14 @@ from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QTabWidget
 
 
 class NotesView(QTabWidget):
+    SECTION_TITLE = "الملاحظات"
+
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self.addTab(self._create_tab('محتوى التبويب 1'), 'تبويب 1')
-        self.addTab(self._create_tab('محتوى التبويب 2'), 'تبويب 2')
+
+        for i in (1, 2):
+            tab_name = f"تبويب {i} {self.SECTION_TITLE}"
+            self.addTab(self._create_tab(f"محتوى {tab_name}"), tab_name)
 
     def _create_tab(self, text: str) -> QWidget:
         widget = QWidget()

--- a/app/modules/projects/view.py
+++ b/app/modules/projects/view.py
@@ -2,10 +2,14 @@ from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QTabWidget
 
 
 class ProjectsView(QTabWidget):
+    SECTION_TITLE = "المشاريع"
+
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self.addTab(self._create_tab('محتوى التبويب 1'), 'تبويب 1')
-        self.addTab(self._create_tab('محتوى التبويب 2'), 'تبويب 2')
+
+        for i in (1, 2):
+            tab_name = f"تبويب {i} {self.SECTION_TITLE}"
+            self.addTab(self._create_tab(f"محتوى {tab_name}"), tab_name)
 
     def _create_tab(self, text: str) -> QWidget:
         widget = QWidget()

--- a/app/modules/settings/view.py
+++ b/app/modules/settings/view.py
@@ -2,10 +2,14 @@ from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QTabWidget
 
 
 class SettingsView(QTabWidget):
+    SECTION_TITLE = "الإعدادات"
+
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self.addTab(self._create_tab('محتوى التبويب 1'), 'تبويب 1')
-        self.addTab(self._create_tab('محتوى التبويب 2'), 'تبويب 2')
+
+        for i in (1, 2):
+            tab_name = f"تبويب {i} {self.SECTION_TITLE}"
+            self.addTab(self._create_tab(f"محتوى {tab_name}"), tab_name)
 
     def _create_tab(self, text: str) -> QWidget:
         widget = QWidget()


### PR DESCRIPTION
## Summary
- expand EmployeesView to show section-specific tab labels and content
- expand FinanceView to show section-specific tab labels and content
- expand EquipmentView to show section-specific tab labels and content
- expand ProjectsView to show section-specific tab labels and content
- expand DailyOpsView to show section-specific tab labels and content
- expand NotesView to show section-specific tab labels and content
- expand SettingsView to show section-specific tab labels and content

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e35063f48832783ad867c098042be