### PR TITLE
Add Component Guide and appearance settings

### DIFF
--- a/app/core/app_router.py
+++ b/app/core/app_router.py
@@ -18,6 +18,7 @@ class AppRouter(QObject):
             "projects": "app.modules.projects.view.ProjectsView",
             "daily_ops": "app.modules.daily_ops.view.DailyOpsView",
             "notes": "app.modules.notes.view.NotesView",
+            "component_guide": "app.modules.component_guide.view.ComponentGuideView",
             "settings": "app.modules.settings.view.SettingsView",
         }
 

--- a/app/core/style_manager.py
+++ b/app/core/style_manager.py
@@ -1,0 +1,36 @@
+from PySide6.QtWidgets import QApplication
+from PySide6.QtGui import QPalette, QColor, QFont
+from PySide6.QtCore import Qt
+
+
+class StyleManager:
+    """Simple style manager for colors, fonts and theme."""
+
+    primary_color: str = "#f47824"
+    secondary_color: str = "#333333"
+    font_family: str = "Arial"
+    font_size: int = 12
+    dark_mode: bool = False
+
+    @classmethod
+    def apply(cls, app: QApplication | None = None) -> None:
+        app = app or QApplication.instance()
+        if not app:
+            return
+        palette = app.palette()
+        if cls.dark_mode:
+            palette.setColor(QPalette.Window, QColor("#222222"))
+            palette.setColor(QPalette.WindowText, Qt.white)
+        else:
+            palette.setColor(QPalette.Window, Qt.white)
+            palette.setColor(QPalette.WindowText, Qt.black)
+
+        palette.setColor(QPalette.Button, QColor(cls.primary_color))
+        palette.setColor(QPalette.ButtonText, Qt.white)
+        app.setPalette(palette)
+
+        font = QFont(cls.font_family, cls.font_size)
+        app.setFont(font)
+        app.setStyleSheet(
+            f"QWidget{{font-family:'{cls.font_family}';font-size:{cls.font_size}pt;}}"
+        )

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt
 
 from .core.app_router import AppRouter
+from .core.style_manager import StyleManager
 from .widgets import HeaderWidget, SidebarWidget, FooterWidget
 
 
@@ -17,6 +18,7 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.setWindowTitle("منصة السعادة")
         self.setLayoutDirection(Qt.RightToLeft)
+        StyleManager.apply()
 
         central = QWidget()
         self.setCentralWidget(central)

--- a/app/modules/component_guide/__init__.py
+++ b/app/modules/component_guide/__init__.py
@@ -1,0 +1,1 @@
+from .view import ComponentGuideView

--- a/app/modules/component_guide/view.py
+++ b/app/modules/component_guide/view.py
@@ -1,0 +1,131 @@
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QGroupBox,
+    QPushButton,
+    QLineEdit,
+    QSpinBox,
+    QComboBox,
+    QLabel,
+    QTableWidget,
+    QTableWidgetItem,
+    QDialog,
+    QDialogButtonBox,
+    QTabWidget,
+    QScrollArea,
+    QStyle,
+    QToolButton,
+)
+from PySide6.QtCore import Qt
+
+from ...core.style_manager import StyleManager
+
+
+class ComponentGuideView(QScrollArea):
+    SECTION_TITLE = "دليل المكونات"
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWidgetResizable(True)
+        container = QWidget()
+        self.setWidget(container)
+        layout = QVBoxLayout(container)
+        layout.setAlignment(Qt.AlignTop)
+
+        layout.addWidget(self._create_buttons())
+        layout.addWidget(self._create_inputs())
+        layout.addWidget(self._create_table())
+        layout.addWidget(self._create_tabs())
+        layout.addWidget(self._create_labels())
+        layout.addWidget(self._create_icons())
+        layout.addStretch()
+
+    def _create_buttons(self) -> QGroupBox:
+        box = QGroupBox("الأزرار")
+        l = QVBoxLayout(box)
+        l.addWidget(QPushButton("افتراضي"))
+        primary = QPushButton("أساسي")
+        primary.setStyleSheet(
+            f"background-color: {StyleManager.primary_color}; color: white;"
+        )
+        l.addWidget(primary)
+        secondary = QPushButton("ثانوي")
+        secondary.setStyleSheet(
+            f"background-color: {StyleManager.secondary_color}; color: white;"
+        )
+        l.addWidget(secondary)
+        icon_btn = QPushButton("مع أيقونة")
+        icon_btn.setIcon(self.style().standardIcon(QStyle.SP_DesktopIcon))
+        l.addWidget(icon_btn)
+        dialog_btn = QPushButton("حوار")
+        dialog_btn.clicked.connect(self._show_dialog)
+        l.addWidget(dialog_btn)
+        return box
+
+    def _create_inputs(self) -> QGroupBox:
+        box = QGroupBox("حقول الإدخال")
+        l = QVBoxLayout(box)
+        l.addWidget(QLineEdit("نص افتراضي"))
+        spin = QSpinBox()
+        l.addWidget(spin)
+        combo = QComboBox()
+        combo.addItems(["خيار 1", "خيار 2", "خيار 3"])
+        l.addWidget(combo)
+        chk = QPushButton("زر تبديل")
+        chk.setCheckable(True)
+        l.addWidget(chk)
+        return box
+
+    def _create_table(self) -> QGroupBox:
+        box = QGroupBox("جدول")
+        l = QVBoxLayout(box)
+        table = QTableWidget(3, 3)
+        table.setHorizontalHeaderLabels(["عمود 1", "عمود 2", "عمود 3"])
+        for r in range(3):
+            for c in range(3):
+                table.setItem(r, c, QTableWidgetItem(f"{r+1}-{c+1}"))
+        l.addWidget(table)
+        return box
+
+    def _create_tabs(self) -> QGroupBox:
+        box = QGroupBox("التبويبات")
+        l = QVBoxLayout(box)
+        tabs = QTabWidget()
+        tabs.addTab(QLabel("محتوى التبويب الأول"), "الأول")
+        tabs.addTab(QLabel("محتوى التبويب الثاني"), "الثاني")
+        l.addWidget(tabs)
+        return box
+
+    def _create_labels(self) -> QGroupBox:
+        box = QGroupBox("التسميات")
+        l = QVBoxLayout(box)
+        lbl1 = QLabel("نص عادي")
+        l.addWidget(lbl1)
+        primary = QLabel("لون أساسي")
+        primary.setStyleSheet(f"color: {StyleManager.primary_color};")
+        l.addWidget(primary)
+        secondary = QLabel("لون ثانوي")
+        secondary.setStyleSheet(f"color: {StyleManager.secondary_color};")
+        l.addWidget(secondary)
+        return box
+
+    def _create_icons(self) -> QGroupBox:
+        box = QGroupBox("أيقونات")
+        l = QVBoxLayout(box)
+        tool = QToolButton()
+        tool.setText("أيقونة")
+        tool.setIcon(self.style().standardIcon(QStyle.SP_DesktopIcon))
+        l.addWidget(tool)
+        return box
+
+    def _show_dialog(self) -> None:
+        dialog = QDialog(self)
+        dialog.setWindowTitle("مربع حوار")
+        dialog_layout = QVBoxLayout(dialog)
+        dialog_layout.addWidget(QLabel("مثال لمربع حوار"))
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(dialog.accept)
+        buttons.rejected.connect(dialog.reject)
+        dialog_layout.addWidget(buttons)
+        dialog.exec()
+

--- a/app/modules/settings/view.py
+++ b/app/modules/settings/view.py
@@ -1,4 +1,16 @@
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QTabWidget
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QTabWidget,
+    QComboBox,
+    QPushButton,
+    QColorDialog,
+    QCheckBox,
+)
+from PySide6.QtGui import QColor
+from PySide6.QtCore import Qt
+from ...core.style_manager import StyleManager
 
 
 class SettingsView(QTabWidget):
@@ -7,12 +19,62 @@ class SettingsView(QTabWidget):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
 
-        for i in (1, 2):
-            tab_name = f"تبويب {i} {self.SECTION_TITLE}"
-            self.addTab(self._create_tab(f"محتوى {tab_name}"), tab_name)
+        self.addTab(self._create_appearance_tab(), "المظهر")
+        self.addTab(self._create_tab("محتوى تبويب 2 الإعدادات"), "تبويب 2 الإعدادات")
 
     def _create_tab(self, text: str) -> QWidget:
         widget = QWidget()
         layout = QVBoxLayout(widget)
         layout.addWidget(QLabel(text))
         return widget
+
+    def _create_appearance_tab(self) -> QWidget:
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+
+        btn_primary = QPushButton("تغيير اللون الأساسي")
+        btn_primary.clicked.connect(lambda: self._choose_color("primary"))
+        layout.addWidget(btn_primary)
+
+        btn_secondary = QPushButton("تغيير اللون الثانوي")
+        btn_secondary.clicked.connect(lambda: self._choose_color("secondary"))
+        layout.addWidget(btn_secondary)
+
+        font_combo = QComboBox()
+        font_combo.addItems(["Arial", "Times New Roman", "Cairo", "Amiri"])
+        font_combo.currentTextChanged.connect(self._font_changed)
+        layout.addWidget(font_combo)
+
+        size_combo = QComboBox()
+        size_combo.addItems(["كبير", "متوسط", "صغير"])
+        size_combo.currentTextChanged.connect(self._size_changed)
+        layout.addWidget(size_combo)
+
+        mode_chk = QCheckBox("الوضع الداكن")
+        mode_chk.stateChanged.connect(self._mode_changed)
+        layout.addWidget(mode_chk)
+
+        layout.addStretch()
+        return widget
+
+    # slots
+    def _choose_color(self, which: str) -> None:
+        current = getattr(StyleManager, f"{which}_color")
+        color = QColorDialog.getColor(QColor(current), self)
+        if color.isValid():
+            setattr(StyleManager, f"{which}_color", color.name())
+            StyleManager.apply()
+
+    def _font_changed(self, font: str) -> None:
+        if font:
+            StyleManager.font_family = font
+            StyleManager.apply()
+
+    def _size_changed(self, text: str) -> None:
+        size_map = {"كبير": 16, "متوسط": 12, "صغير": 10}
+        StyleManager.font_size = size_map.get(text, 12)
+        StyleManager.apply()
+
+    def _mode_changed(self, state: int) -> None:
+        StyleManager.dark_mode = state == Qt.Checked
+        StyleManager.apply()

--- a/app/widgets/sidebar.py
+++ b/app/widgets/sidebar.py
@@ -16,6 +16,7 @@ class SidebarWidget(QWidget):
         self._buttons: dict[str, QPushButton] = {}
         sections = [
             ("dashboard", "الرئيسية"),
+            ("component_guide", "دليل المكونات"),
             ("employees", "العاملون"),
             ("finance", "المالية"),
             ("equipment", "المعدات"),

--- a/docs/development_log.md
+++ b/docs/development_log.md
@@ -69,3 +69,31 @@
 > أي قسم جديد أو تعديل مستقبلي يجب توثيقه بنفس النمط (تاريخ - مسار الملف - وصف التعديل).
 
 **مسطر تجريبة:**  
+
+## 2025-06-27
+
+---
+
+**إضافة صفحة دليل المكونات**
+
+- **D:\Alsaada-ERP\Alsaada_ERP_Platform\app\modules\component_guide\view.py**
+    - إنشاء صفحة تستعرض المكونات الأساسية للتطبيق (أزرار، جداول، حقول، حوارات، تبويبات، تسميات وأيقونات) مع دعم العربية واتجاه RTL.
+- **D:\Alsaada-ERP\Alsaada_ERP_Platform\app\modules\component_guide\__init__.py**
+    - تصدير الواجهة الجديدة.
+- **D:\Alsaada-ERP\Alsaada_ERP_Platform\app\core\app_router.py**
+    - إضافة مسار "component_guide" لعرض الصفحة الجديدة.
+- **D:\Alsaada-ERP\Alsaada_ERP_Platform\app\widgets\sidebar.py**
+    - إظهار "دليل المكونات" في الشريط الجانبي.
+
+**تحسين الإعدادات وإدارة المظهر**
+
+- **D:\Alsaada-ERP\Alsaada_ERP_Platform\app\core\style_manager.py**
+    - إضافة مدير أنماط بسيط للتحكم في الألوان والخط والوضع الليلي.
+- **D:\Alsaada-ERP\Alsaada_ERP_Platform\app\modules\settings\view.py**
+    - استبدال تبويب 1 بتبويب "المظهر" يتيح تغيير الألوان والخط والحجم والوضع الليلي مع تطبيق فوري.
+- **D:\Alsaada-ERP\Alsaada_ERP_Platform\app\main_window.py**
+    - استدعاء StyleManager لتطبيق المظهر عند تشغيل التطبيق.
+
+**جميع التعديلات الحالية تمت بواسطة: صالح عثمان**
+
+---


### PR DESCRIPTION
## Summary
- add a simple style manager
- implement Component Guide page showing widgets
- expose the page in the sidebar and router
- add appearance tab in Settings for colors, fonts and mode
- apply style manager from main window
- document updates in development log

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e46595fe48327ba42a1b51d8885a5