### PR TITLE
Add icons to sidebar sections

### DIFF
--- a/app/widgets/sidebar.py
+++ b/app/widgets/sidebar.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import QWidget, QPushButton, QVBoxLayout, QLabel
+from PySide6.QtWidgets import QWidget, QPushButton, QVBoxLayout, QLabel, QStyle
 from PySide6.QtCore import Qt, Signal
 
 
@@ -15,19 +15,20 @@ class SidebarWidget(QWidget):
 
         self._buttons: dict[str, QPushButton] = {}
         sections = [
-            ("dashboard", "الرئيسية"),
-            ("component_guide", "دليل المكونات"),
-            ("employees", "العاملون"),
-            ("finance", "المالية"),
-            ("equipment", "المعدات"),
-            ("projects", "المشاريع"),
-            ("daily_ops", "العمليات اليومية"),
-            ("notes", "الملاحظات"),
-            ("settings", "الإعدادات"),
+            ("dashboard", "الرئيسية", QStyle.SP_DesktopIcon),
+            ("component_guide", "دليل المكونات", QStyle.SP_FileDialogListView),
+            ("employees", "العاملون", QStyle.SP_ComputerIcon),
+            ("finance", "المالية", QStyle.SP_DriveHDIcon),
+            ("equipment", "المعدات", QStyle.SP_DriveNetIcon),
+            ("projects", "المشاريع", QStyle.SP_DirIcon),
+            ("daily_ops", "العمليات اليومية", QStyle.SP_FileDialogDetailedView),
+            ("notes", "الملاحظات", QStyle.SP_FileDialogInfoView),
+            ("settings", "الإعدادات", QStyle.SP_FileDialogDetailedView),
         ]
 
-        for key, text in sections:
+        for key, text, icon in sections:
             button = QPushButton(text)
+            button.setIcon(self.style().standardIcon(icon))
             button.clicked.connect(lambda _=False, k=key: self.navigate.emit(k))
             layout.addWidget(button)
             self._buttons[key] = button


### PR DESCRIPTION
## Summary
- add standard icons to all sidebar buttons for clearer navigation

## Testing
- `python -m py_compile app/widgets/sidebar.py app/main_window.py app/core/app_router.py app/modules/component_guide/view.py`
- `python run.py` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_685e4a2658348327b4403c4cc0229d99