### PR TITLE
Implement ThemeManager and global QSS

### DIFF
--- a/app/core/theme_manager.py
+++ b/app/core/theme_manager.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+from PySide6.QtWidgets import QApplication
+
+
+class ThemeManager:
+    """Central manager for theme colors and styling."""
+
+    # Base palette
+    palette: dict[str, str] = {
+        "primary": "#f47824",
+        "primary_light": "#ffa96b",
+        "primary_dark": "#b35c1c",
+        "primary_disabled": "#fbd3ba",
+        "secondary": "#333333",
+        "secondary_light": "#4f4f4f",
+        "secondary_dark": "#1a1a1a",
+        "secondary_disabled": "#777777",
+        "success": "#28a745",
+        "warning": "#ffc107",
+        "error": "#dc3545",
+    }
+
+    font_family: str = "Arial"
+    font_size: int = 12
+
+    radius_small: int = 4
+    radius_medium: int = 8
+    spacing: int = 8
+
+    @classmethod
+    def apply(cls, app: QApplication | None = None) -> None:
+        """Apply current palette and style sheets to the application."""
+        app = app or QApplication.instance()
+        if not app:
+            return
+        style_dir = Path(__file__).resolve().parents[2] / "styles"
+        qss_path = style_dir / "main.qss"
+        if qss_path.exists():
+            with open(qss_path, "r", encoding="utf-8") as f:
+                qss_template = f.read()
+            variables = {
+                **cls.palette,
+                "font_family": cls.font_family,
+                "font_size": cls.font_size,
+                "radius_small": cls.radius_small,
+                "radius_medium": cls.radius_medium,
+                "spacing": cls.spacing,
+            }
+            app.setStyleSheet(qss_template.format(**variables))
+
+    @classmethod
+    def update(cls, **kwargs: str) -> None:
+        """Update palette values then reapply styles."""
+        for key, value in kwargs.items():
+            if key in cls.palette:
+                cls.palette[key] = value
+            elif hasattr(cls, key):
+                setattr(cls, key, value)
+        cls.apply()

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -10,6 +10,7 @@ from PySide6.QtCore import Qt
 
 from .core.app_router import AppRouter
 from .core.style_manager import StyleManager
+from .core.theme_manager import ThemeManager
 from .widgets import HeaderWidget, SidebarWidget, FooterWidget
 
 
@@ -19,6 +20,7 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("منصة السعادة")
         self.setLayoutDirection(Qt.RightToLeft)
         StyleManager.apply()
+        ThemeManager.apply()
 
         central = QWidget()
         self.setCentralWidget(central)
@@ -40,7 +42,10 @@ class MainWindow(QMainWindow):
 
         self.stack = QStackedWidget()
         self.stack.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        body_layout.addWidget(self.stack, 1)
+        body_layout.addWidget(self.stack)
+        # Use golden ratio for sidebar vs main area (100:162 ≈ 1:1.618)
+        body_layout.setStretch(0, 100)
+        body_layout.setStretch(1, 162)
 
         main_layout.addWidget(body, 1)
 

--- a/app/modules/component_guide/view.py
+++ b/app/modules/component_guide/view.py
@@ -1,6 +1,7 @@
 from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
+    QHBoxLayout,
     QGroupBox,
     QPushButton,
     QLineEdit,
@@ -18,7 +19,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt
 
-from ...core.style_manager import StyleManager
+from ...core.theme_manager import ThemeManager
 
 
 class ComponentGuideView(QScrollArea):
@@ -31,7 +32,10 @@ class ComponentGuideView(QScrollArea):
         self.setWidget(container)
         layout = QVBoxLayout(container)
         layout.setAlignment(Qt.AlignTop)
+        # Use golden ratio spacing between demo blocks
+        layout.setSpacing(int(ThemeManager.spacing * 1.618))
 
+        layout.addWidget(self._create_palette_preview())
         layout.addWidget(self._create_buttons())
         layout.addWidget(self._create_inputs())
         layout.addWidget(self._create_table())
@@ -40,19 +44,40 @@ class ComponentGuideView(QScrollArea):
         layout.addWidget(self._create_icons())
         layout.addStretch()
 
+    def _create_palette_preview(self) -> QGroupBox:
+        box = QGroupBox("لوحة الألوان")
+        l = QHBoxLayout(box)
+        for key in [
+            "primary",
+            "primary_light",
+            "primary_dark",
+            "secondary",
+            "secondary_light",
+            "secondary_dark",
+            "success",
+            "warning",
+            "error",
+        ]:
+            lbl = QLabel(key)
+            lbl.setObjectName(f"color_{key}")
+            lbl.setProperty("class", "color-preview")
+            lbl.setFixedSize(62, 38)  # width:height ≈ golden ratio
+            l.addWidget(lbl)
+        l.addStretch()
+        return box
+
     def _create_buttons(self) -> QGroupBox:
         box = QGroupBox("الأزرار")
         l = QVBoxLayout(box)
-        l.addWidget(QPushButton("افتراضي"))
+        default_btn = QPushButton("افتراضي")
+        default_btn.setObjectName("defaultButton")
+        l.addWidget(default_btn)
+
         primary = QPushButton("أساسي")
-        primary.setStyleSheet(
-            f"background-color: {StyleManager.primary_color}; color: white;"
-        )
+        primary.setObjectName("primaryButton")
         l.addWidget(primary)
         secondary = QPushButton("ثانوي")
-        secondary.setStyleSheet(
-            f"background-color: {StyleManager.secondary_color}; color: white;"
-        )
+        secondary.setObjectName("secondaryButton")
         l.addWidget(secondary)
         icon_btn = QPushButton("مع أيقونة")
         icon_btn.setIcon(self.style().standardIcon(QStyle.SP_DesktopIcon))
@@ -102,10 +127,10 @@ class ComponentGuideView(QScrollArea):
         lbl1 = QLabel("نص عادي")
         l.addWidget(lbl1)
         primary = QLabel("لون أساسي")
-        primary.setStyleSheet(f"color: {StyleManager.primary_color};")
+        primary.setObjectName("primaryLabel")
         l.addWidget(primary)
         secondary = QLabel("لون ثانوي")
-        secondary.setStyleSheet(f"color: {StyleManager.secondary_color};")
+        secondary.setObjectName("secondaryLabel")
         l.addWidget(secondary)
         return box
 

--- a/app/modules/settings/view.py
+++ b/app/modules/settings/view.py
@@ -11,6 +11,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtGui import QColor
 from PySide6.QtCore import Qt
 from ...core.style_manager import StyleManager
+from ...core.theme_manager import ThemeManager
 
 
 class SettingsView(QTabWidget):
@@ -59,20 +60,20 @@ class SettingsView(QTabWidget):
 
     # slots
     def _choose_color(self, which: str) -> None:
-        current = getattr(StyleManager, f"{which}_color")
+        current = ThemeManager.palette.get(which, "#ffffff")
         color = QColorDialog.getColor(QColor(current), self)
         if color.isValid():
-            setattr(StyleManager, f"{which}_color", color.name())
+            ThemeManager.update(**{which: color.name()})
             StyleManager.apply()
 
     def _font_changed(self, font: str) -> None:
         if font:
-            StyleManager.font_family = font
+            ThemeManager.update(font_family=font)
             StyleManager.apply()
 
     def _size_changed(self, text: str) -> None:
         size_map = {"كبير": 16, "متوسط": 12, "صغير": 10}
-        StyleManager.font_size = size_map.get(text, 12)
+        ThemeManager.update(font_size=size_map.get(text, 12))
         StyleManager.apply()
 
     def _mode_changed(self, state: int) -> None:

--- a/styles/main.qss
+++ b/styles/main.qss
@@ -1,0 +1,104 @@
+/* Global application styles using ThemeManager variables */
+
+QWidget {
+    font-family: {font_family};
+    font-size: {font_size}pt;
+}
+
+QPushButton {
+    padding: 6px 12px;
+    border-radius: {radius_small}px;
+}
+
+QPushButton#primaryButton {
+    background-color: {primary};
+    color: white;
+}
+QPushButton#primaryButton:hover {
+    background-color: {primary_light};
+}
+QPushButton#primaryButton:pressed {
+    background-color: {primary_dark};
+}
+QPushButton#primaryButton:disabled {
+    background-color: {primary_disabled};
+}
+
+QPushButton#secondaryButton {
+    background-color: {secondary};
+    color: white;
+}
+QPushButton#secondaryButton:hover {
+    background-color: {secondary_light};
+}
+QPushButton#secondaryButton:pressed {
+    background-color: {secondary_dark};
+}
+QPushButton#secondaryButton:disabled {
+    background-color: {secondary_disabled};
+}
+
+QLineEdit, QComboBox, QSpinBox {
+    border: 1px solid {secondary_light};
+    border-radius: {radius_small}px;
+    padding: 4px;
+}
+QLineEdit:focus, QComboBox:focus, QSpinBox:focus {
+    border-color: {primary};
+}
+
+QGroupBox {
+    margin-top: {spacing}px;
+    border: 1px solid {secondary_light};
+    border-radius: {radius_medium}px;
+    padding: {spacing}px;
+}
+QGroupBox::title {
+    subcontrol-origin: margin;
+    subcontrol-position: top right;
+    padding: 0 {spacing}px;
+}
+
+QTableWidget {
+    border: 1px solid {secondary_light};
+}
+QHeaderView::section {
+    background: {secondary_light};
+    padding: 4px;
+    border: none;
+}
+QTabWidget::pane {
+    border: 1px solid {secondary_light};
+}
+QTabBar::tab:selected {
+    background: {primary};
+    color: white;
+}
+QTabBar::tab:hover {
+    background: {primary_light};
+}
+
+QLabel#primaryLabel {
+    color: {primary};
+}
+QLabel#secondaryLabel {
+    color: {secondary};
+}
+
+/* Palette preview labels */
+QLabel[class="color-preview"] {
+    min-width: 60px;
+    border-radius: {radius_small}px;
+    padding: 4px;
+    color: white;
+    margin-right: 4px;
+}
+#color_primary { background: {primary}; }
+#color_primary_light { background: {primary_light}; }
+#color_primary_dark { background: {primary_dark}; }
+#color_secondary { background: {secondary}; }
+#color_secondary_light { background: {secondary_light}; }
+#color_secondary_dark { background: {secondary_dark}; }
+#color_success { background: {success}; }
+#color_warning { background: {warning}; color: black; }
+#color_error { background: {error}; }


### PR DESCRIPTION
## Summary
- add `ThemeManager` to manage a centralized color palette
- apply new theme in `MainWindow` with golden ratio body layout
- enable color/size changes in settings using `ThemeManager`
- update Component Guide with palette preview and golden‑ratio spacing
- create comprehensive `styles/main.qss`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `QT_QPA_PLATFORM=offscreen python run.py` *(fails: ModuleNotFoundError: No module named 'PySide6')*


------
https://chatgpt.com/codex/tasks/task_e_685e5140bef48327be2aa10cae664f6c