### PR TITLE
Fix theme customization controls

### DIFF
--- a/app/core/style_manager.py
+++ b/app/core/style_manager.py
@@ -31,4 +31,4 @@ class StyleManager:
         app.setFont(font)
         ThemeManager.font_family = cls.font_family
         ThemeManager.font_size = cls.font_size
-        ThemeManager.switch_mode(cls.dark_mode)
+        ThemeManager.apply()

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -24,8 +24,8 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.setWindowTitle("منصة السعادة")
         self.setLayoutDirection(Qt.RightToLeft)
+        ThemeManager.switch_mode(StyleManager.dark_mode)
         StyleManager.apply()
-        ThemeManager.apply()
 
         central = QWidget()
         self.setCentralWidget(central)

--- a/app/modules/settings/view.py
+++ b/app/modules/settings/view.py
@@ -63,18 +63,18 @@ class SettingsView(QTabWidget):
         color = QColorDialog.getColor(QColor(current), self)
         if color.isValid():
             ThemeManager.update(**{which: color.name()})
-            StyleManager.apply()
 
     def _font_changed(self, font: str) -> None:
         if font:
-            ThemeManager.update(font_family=font)
+            StyleManager.font_family = font
             StyleManager.apply()
 
     def _size_changed(self, text: str) -> None:
         size_map = {"كبير": 16, "متوسط": 12, "صغير": 10}
-        ThemeManager.update(font_size=size_map.get(text, 12))
+        StyleManager.font_size = size_map.get(text, 12)
         StyleManager.apply()
 
     def _mode_changed(self, state: int) -> None:
         StyleManager.dark_mode = state == Qt.Checked
+        ThemeManager.switch_mode(StyleManager.dark_mode)
         StyleManager.apply()


### PR DESCRIPTION
## Summary
- don't reset palette when applying style
- update dark mode and font settings in settings view
- initialize theme mode before applying styles in MainWindow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e724917a88327aac150e645a901e6