### PR TITLE
Set Cairo as default font

### DIFF
--- a/app/core/style_manager.py
+++ b/app/core/style_manager.py
@@ -8,8 +8,8 @@ from .theme_manager import ThemeManager
 class StyleManager:
     """إدارة الخطوط وتطبيق الوضع الليلي."""
 
-    font_family: str = "Arial"
-    font_size: int = 12
+    font_family: str = "Cairo"
+    font_size: int = 10
     dark_mode: bool = True
 
     @classmethod

--- a/app/core/theme_manager.py
+++ b/app/core/theme_manager.py
@@ -61,8 +61,8 @@ class ThemeManager:
 
     palette: dict[str, str] = dark_palette.copy()
 
-    font_family: str = "Arial"
-    font_size: int = 12
+    font_family: str = "Cairo"
+    font_size: int = 10
 
     radius_small: int = 4
     radius_medium: int = 8

--- a/docs/development_log.md
+++ b/docs/development_log.md
@@ -98,6 +98,21 @@
 
 ---
 
+## 2025-07-03
+
+---
+
+**تعديل القيم الافتراضية للخطوط**
+
+- **D:\Alsaada-ERP\Alsaada_ERP_Platform\app\core\style_manager.py**
+    - ضبط الخط الافتراضي ليكون Cairo والحجم 10 (صغير).
+- **D:\Alsaada-ERP\Alsaada_ERP_Platform\app\core\theme_manager.py**
+    - مزامنة القيم الافتراضية للخط والحجم مع StyleManager.
+
+**جميع التعديلات الحالية تمت بواسطة: صالح عثمان**
+
+---
+
 ## 2025-07-02
 
 ---


### PR DESCRIPTION
## Summary
- use Cairo as the default application font
- set default text size to small (10pt)
- document the font change in the development log

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e84821c6883278873b7ab2a172b1d