### PR TITLE
Fix sidebar icon color

### DIFF
--- a/styles/sidebar.qss
+++ b/styles/sidebar.qss
@@ -27,7 +27,7 @@ SidebarWidget QPushButton {
 }
 
 SidebarWidget[collapsed="true"] QPushButton {
-    color: {secondary};
+    color: {primary};
     qproperty-iconSize: {icon_size_collapsed}px {icon_size_collapsed}px;
 }
 


### PR DESCRIPTION
## Summary
- icons in collapsed sidebar use the primary color instead of secondary

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_685e84ab1ff48327a1bb6483d1207804