### PR TITLE
Add sidebar section dividers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/app/widgets/sidebar.py
+++ b/app/widgets/sidebar.py
@@ -80,7 +80,7 @@ class SidebarWidget(QWidget):
             ("settings", "الإعدادات", "fa5s.cog", icon_dir / "settings.svg"),
         ]
 
-        for key, text, fa_name, icon in sections:
+        for i, (key, text, fa_name, icon) in enumerate(sections):
             button = QPushButton("", self)
             button.setLayoutDirection(Qt.RightToLeft)
             if qta:
@@ -94,6 +94,10 @@ class SidebarWidget(QWidget):
             button._label = text  # type: ignore[attr-defined]
             layout.addWidget(button)
             self._buttons[key] = button
+            if i < len(sections) - 1:
+                sep = QFrame()
+                sep.setFrameShape(QFrame.HLine)
+                layout.addWidget(sep)
 
         divider = QFrame()
         divider.setFrameShape(QFrame.HLine)

--- a/styles/sidebar.qss
+++ b/styles/sidebar.qss
@@ -54,6 +54,14 @@ SidebarWidget QFrame {
     border-top: 1px solid {secondary_light};
 }
 
+SidebarWidget[collapsed="false"] QFrame {
+    border-color: {primary};
+}
+
+SidebarWidget[collapsed="true"] QFrame {
+    border-color: {secondary};
+}
+
 SidebarWidget QLabel {
     margin-top: {spacing}px;
     margin-bottom: {spacing}px;


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore Python cache files
- add dynamic QFrame style for expanded/collapsed sidebar
- insert QFrame separators between sidebar buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e84f3ed6883278788eda7fb306a60