### PR TITLE
Fix sidebar module IndentationError

### DIFF
--- a/app/widgets/sidebar.py
+++ b/app/widgets/sidebar.py
@@ -227,7 +227,6 @@ class SidebarWidget(QWidget):
             btn.setGraphicsEffect(None)
 
 
-             codex/refactor-sidebar-styling-and-qss-integration
 
             btn.setText("" if collapsed else btn._label)
             if not collapsed and is_active:


### PR DESCRIPTION
## Summary
- remove leftover merge marker from `app/widgets/sidebar.py`

## Testing
- `python run.py` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_685ebd9a3c28832796290b367a988047