### PR TITLE
Ensure collapsed sidebar uses primary color

### DIFF
--- a/styles/sidebar.qss
+++ b/styles/sidebar.qss
@@ -10,11 +10,13 @@ SidebarWidget {
 }
 
 SidebarWidget[collapsed="true"] {
-    background: {primary};
+    /* collapsed sidebar uses the primary color */
+    background-color: {primary};
 }
 
 SidebarWidget[collapsed="false"] {
-    background: {secondary};
+    /* expanded sidebar retains the secondary background */
+    background-color: {secondary};
 }
 
 SidebarWidget QPushButton {


### PR DESCRIPTION
## Summary
- tweak sidebar QSS so collapsed navigation bar uses primary color explicitly

## Testing
- *(no tests included in repo)*

------
https://chatgpt.com/codex/tasks/task_e_685ec17ef8b88327b9cc160caccd1a4b