### PR TITLE
Fix sidebar active item centering

### DIFF
--- a/styles/sidebar.qss
+++ b/styles/sidebar.qss
@@ -51,6 +51,13 @@ SidebarWidget QPushButton[active="true"] {
     color: {secondary};
 }
 
+/* توسيط العنصر الفعّال عند فتح القائمة لكل من الوضعين الغامق والفاتح */
+SidebarWidget[collapsed="false"] QPushButton[active="true"] {
+    padding-left: 0px;
+    padding-right: 0px;
+    text-align: center;
+}
+
 
 SidebarWidget QFrame {
     margin-top: {spacing}px;


### PR DESCRIPTION
## Summary
- center the active menu item when the sidebar is expanded

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ec209b6b083278d5d0affd11edfe6